### PR TITLE
Improving notifications

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -4,15 +4,25 @@ var BADGE_BACKGROUND_COLOR = '#d73f31';
 
 var refreshTimeout;
 var last_unread_count = 0;
-var notification;
+var notificationTimeout;
 
 function showNotification(title, body) {
   if (localStorage['show_notifications'] != 'yes') {
     return;
   }
-  notification = webkitNotifications.createNotification('icon-48.png', title, body);
+  
+  var notification = webkitNotifications.createNotification('icon-48.png', title, body);
   notification.tag = "theoldreader-chrome"; // Will update the notification instead of creating a new one
-  notification.onclick = function(){ openOurTab(); this.close() } // Opens the Old Reader page and self-destructs
+  notification.onclick = function() { openOurTab(); this.close(); } // Opens the Old Reader page and self-destructs
+  
+  if (notificationTimeout) { window.clearTimeout(notificationTimeout); } // If updating a notification, reset timeout
+  if (localStorage['notification_timeout'] > 0) {
+    notificationTimeout = window.setTimeout( 
+      function() { notification.cancel(); }, 
+      localStorage['notification_timeout'] * 1000
+    );
+  }
+  
   notification.show();
 }
 

--- a/options.html
+++ b/options.html
@@ -14,6 +14,7 @@
 			</select>
 		</p>
 		<p><label for="show_notifications">Show popup notifications: <input type="checkbox" id="show_notifications"></p>
+		<p><label for="notification_timeout">Auto-close notification after <input type="number" min="0" max="999" id="notification_timeout"> seconds (0 to keep open)</p>
 		<p><label for="prefer_https">Prefer connecting over https: <input type="checkbox" id="prefer_https"></p>
 		<p>
 			<button id="save_button">Save</button>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@
 function save_options() {
   localStorage['click_page'] = $('#click_page').val();
   localStorage['show_notifications'] = $('#show_notifications').prop('checked') ? 'yes' : 'no';
+  localStorage['notification_timeout'] = parseInt($('#notification_timeout').val());
   localStorage['prefer_https'] = $('#prefer_https').prop('checked') ? 'yes' : 'no';
   $('#save_notification').fadeIn('fast').delay(2000).fadeOut('fast');
 }
@@ -13,6 +14,7 @@ function load_options() {
   if (localStorage['show_notifications'] == 'yes') {
     $('#show_notifications').prop('checked', true);
   }
+  $('#notification_timeout').val(localStorage['notification_timeout'] || 0);
   if (localStorage['prefer_https'] == 'yes') {
     $('#prefer_https').prop('checked', true);
   }


### PR DESCRIPTION
1) Prevent "You have 0 unread post" on launch
2) Make a new notification replace the old one via tags
3) Add `onclick` function to open the main page and close the notification
4) Add an option to auto-close the notification after N seconds
